### PR TITLE
Removing 'Type' column from the main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,26 @@ Read more [here](https://github.com/tango-controls/rfc/wiki).
 The table below summarises all available or expected specifications. For the current "work in progress status", please 
 check either PRs or [Wiki](https://github.com/tango-controls/rfc/wiki/Work-in-Progress-RFCs).  
 
-Short Name             | Title                                                         | Type     | Status     | Editor
------------------------|---------------------------------------------------------------|----------|------------|-------
-RFC-1   | The Tango control system                                      | Standard | Raw          | Lorenzo Pivetta
-[RFC-2](2/README.md)   | The device object model                                       | Standard | Draft        | Vincent Hardion
-[RFC-3](3/README.md)   | The command model                                             | Standard | Draft      | Sergi Blanchi-Torné
-[RFC-4](4/README.md)   | The attribute model                                           | Standard | Draft        | Sergi Blanchi-Torné
-RFC-5   | The property model                                            | Standard | Raw          | Gwenaelle Abeillé
-[RFC-6](6/README.md)   | The database system                                           | Standard | Draft          | Gwenaelle Abeillé
-RFC-7   | The pipe model                                                | Standard | Raw          |
-RFC-8   | The server model                                              | Standard | Raw          | Lorenzo Pivetta
-RFC-9   | Data types                                                    | Standard | Raw          | 
-RFC-10 | The Request-Reply protocol                                    | Standard | Raw          | Reynald Bourtembourg
-RFC-11 | The Request-Reply protocol - CORBA implementation             | Standard | Raw          | 
-RFC-12 | The Publisher-Subscriber protocol                             | Standard | Raw          | Vincent Hardion 
-RFC-13 | The Publisher-Subscriber protocol - ZeroMQ implementation     | Standard | Raw          | 
-RFC-14 | Logging service                                               | Standard | Raw          | Sergi Blanchi-Torné
-RFC-15 | The dynamic attribute and command                             | Standard | Raw          | 
-RFC-XX | Cache system                                                  | Standard | Raw          | 
-RFC-XX | Memorised attribute service                                   | Standard | Raw          | 
-RFC-XX | Authorisation system                                          | Standard | Raw          | 
-RFC-XX | High Level API                                                | Standard | Raw          | 
-RFC-XX | High Level API - Python implementation                        | Standard | Raw          | 
-RFC-XX | High Level API - Java   implementation                        | Standard | Raw          | 
+Short Name             | Title                                                         | Status     | Editor
+-----------------------|---------------------------------------------------------------|------------|-------
+RFC-1   | The Tango control system                                       | Raw          | Lorenzo Pivetta
+[RFC-2](2/README.md)   | The device object model                                        | Draft        | Vincent Hardion
+[RFC-3](3/README.md)   | The command model                                              | Draft      | Sergi Blanchi-Torné
+[RFC-4](4/README.md)   | The attribute model                                            | Draft        | Sergi Blanchi-Torné
+RFC-5   | The property model                                             | Raw          | Gwenaelle Abeillé
+[RFC-6](6/README.md)   | The database system                                            | Draft          | Gwenaelle Abeillé
+RFC-7   | The pipe model                                                 | Raw          |
+RFC-8   | The server model                                               | Raw          | Lorenzo Pivetta
+RFC-9   | Data types                                                     | Raw          | 
+RFC-10 | The Request-Reply protocol                                     | Raw          | Reynald Bourtembourg
+RFC-11 | The Request-Reply protocol - CORBA implementation              | Raw          | 
+RFC-12 | The Publisher-Subscriber protocol                              | Raw          | Vincent Hardion 
+RFC-13 | The Publisher-Subscriber protocol - ZeroMQ implementation      | Raw          | 
+RFC-14 | Logging service                                                | Raw          | Sergi Blanchi-Torné
+RFC-15 | The dynamic attribute and command                              | Raw          | 
+RFC-XX | Cache system                                                   | Raw          | 
+RFC-XX | Memorised attribute service                                    | Raw          | 
+RFC-XX | Authorisation system                                           | Raw          | 
+RFC-XX | High Level API                                                 | Raw          | 
+RFC-XX | High Level API - Python implementation                         | Raw          | 
+RFC-XX | High Level API - Java   implementation                         | Raw          | 


### PR DESCRIPTION
This follows the decission from the meeting 02.12.209